### PR TITLE
Removed default puppet timeout to successfully provision CentOS boxes.

### DIFF
--- a/manifests/site.pp
+++ b/manifests/site.pp
@@ -63,6 +63,7 @@ node /^centos-7-0/ {
   exec { 'update-rpm-packages':
     command => '/usr/bin/yum update -y',
     creates => '/vagrant/.locks/update-rpm-packages',
+    timeout => 0
   }
 
   package {'epel-release':
@@ -113,6 +114,7 @@ node /^centos/ {
   exec { 'update-rpm-packages':
     command => '/usr/bin/yum update -y',
     creates => '/vagrant/.locks/update-rpm-packages',
+    timeout => 0
   }
 
   package {'epel-release':


### PR DESCRIPTION
Signed-off-by: GabrielNicolasAvellaneda avellaneda.gabriel@gmail.com
